### PR TITLE
Fixed sort order of list

### DIFF
--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -123,8 +123,7 @@ public class AcknowListViewController: UITableViewController {
                     options: [],
                     range: nil,
                     locale: NSLocale.currentLocale())
-
-                return (result.rawValue == NSComparisonResult.OrderedDescending.rawValue)
+                return (result.rawValue == NSComparisonResult.OrderedAscending.rawValue)
              })
 
             self.acknowledgements = sortedAcknowledgements


### PR DESCRIPTION
Sort order of the acknowledement list is reversed.
I expect to it is in ascending order(a to z), but in fact is now in descending(z to a) order.
In fact, In VTAcknowledgementsViewController, the acknowledement list is in ascending.
