### PR TITLE
Update AcknowListViewController.swift

### DIFF
--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -234,7 +234,7 @@ public class AcknowListViewController: UITableViewController {
         if let navigationController = self.navigationController {
             if self.presentingViewController != nil &&
                 navigationController.viewControllers.first == self {
-                    let item = UIBarButtonItem(barButtonSystemItem: .Done, target: self, action: "dismissViewController")
+                    let item = UIBarButtonItem(barButtonSystemItem: .Done, target: self, action: "dismissViewController:")
                     self.navigationItem.leftBarButtonItem = item
             }
         }


### PR DESCRIPTION
Without ":" in the selector "dismissViewController", Xcode will throw an error. Xcode can't recognize this selector.