### PR TITLE
Revert to standard Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
+xcode_workspace: AcknowList.xcworkspace
+xcode_scheme: AcknowList
+xcode_sdk: iphonesimulator
 osx_image: xcode7.3
-
-script:
- - xcodebuild test -workspace AcknowList.xcworkspace -scheme AcknowList -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO


### PR DESCRIPTION
We had to use a custom build script to bypass a bug with Travis CI and Xcode 7.3.

This pull request reverts this change, to switch back to a standard configuration once the problem gets fixed.