### PR TITLE
Show only specified license types

### DIFF
--- a/Source/Acknow.swift
+++ b/Source/Acknow.swift
@@ -36,15 +36,22 @@ public struct Acknow {
     public let text: String
 
     /**
+     The acknowledgement license (for instance the pod' s license type).
+     */
+    public let license: String?
+
+    /**
      Initializes the `Acknow` instance with a title and a text.
 
      - parameter title: The acknowledgement title (for instance the pod’s name).
      - parameter text:  The acknowledgement body text (for instance the pod’s license).
+     - parameter license: The acknowledgement license (for instance the pod' s license type).
 
      - returns: The new `Acknow` instance.
      */
-    public init(title: String, text: String) {
+    public init(title: String, text: String, license: String?) {
         self.title = title
         self.text  = text
+        self.license = license
     }
 }

--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -68,13 +68,14 @@ public class AcknowListViewController: UITableViewController {
      Initializes the `AcknowListViewController` instance for a plist file path.
 
      - parameter acknowledgementsPlistPath: The path to the acknowledgements plist file.
+     - parameter licenses: The licenses to be shown.
 
      - returns: The new `AcknowListViewController` instance.
      */
-    public init(acknowledgementsPlistPath: String?) {
+    public init(acknowledgementsPlistPath: String?, licenses: [String]? = nil) {
         super.init(style: .Grouped)
 
-        self.commonInit(acknowledgementsPlistPath: acknowledgementsPlistPath)
+        self.commonInit(acknowledgementsPlistPath: acknowledgementsPlistPath, licenses: licenses)
     }
 
     /**
@@ -87,14 +88,14 @@ public class AcknowListViewController: UITableViewController {
     public required init(coder aDecoder: NSCoder) {
         super.init(style: .Grouped)
         let path = AcknowListViewController.defaultAcknowledgementsPlistPath()
-        self.commonInit(acknowledgementsPlistPath: path)
+        self.commonInit(acknowledgementsPlistPath: path, licenses: nil)
     }
 
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
 
-    func commonInit(acknowledgementsPlistPath acknowledgementsPlistPath: String?) {
+    func commonInit(acknowledgementsPlistPath acknowledgementsPlistPath: String?, licenses: [String]?) {
         self.title = AcknowLocalization.localizedTitle()
 
         if let acknowledgementsPlistPath = acknowledgementsPlistPath {
@@ -120,7 +121,16 @@ public class AcknowListViewController: UITableViewController {
                 self.footerText = headerFooter.footer
             }
 
-            let acknowledgements = parser.parseAcknowledgements()
+            var acknowledgements = parser.parseAcknowledgements()
+            if let licenses = licenses {
+                acknowledgements = acknowledgements.filter { ack in
+                    if let license = ack.license {
+                        return licenses.contains(license)
+                    } else {
+                        return false
+                    }
+                }
+            }
             let sortedAcknowledgements = acknowledgements.sort({
                 (ack1: Acknow, ack2: Acknow) -> Bool in
                 let result = ack1.title.compare(
@@ -165,7 +175,7 @@ public class AcknowListViewController: UITableViewController {
         }
 
         if let path = path {
-            self.commonInit(acknowledgementsPlistPath: path)
+            self.commonInit(acknowledgementsPlistPath: path, licenses: nil)
         }
     }
 

--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -72,10 +72,10 @@ public class AcknowListViewController: UITableViewController {
 
      - returns: The new `AcknowListViewController` instance.
      */
-    public init(acknowledgementsPlistPath: String?, licenses: [String]? = nil) {
+    public init(acknowledgementsPlistPath: String?) {
         super.init(style: .Grouped)
 
-        self.commonInit(acknowledgementsPlistPath: acknowledgementsPlistPath, licenses: licenses)
+        self.commonInit(acknowledgementsPlistPath: acknowledgementsPlistPath)
     }
 
     /**
@@ -88,14 +88,14 @@ public class AcknowListViewController: UITableViewController {
     public required init(coder aDecoder: NSCoder) {
         super.init(style: .Grouped)
         let path = AcknowListViewController.defaultAcknowledgementsPlistPath()
-        self.commonInit(acknowledgementsPlistPath: path, licenses: nil)
+        self.commonInit(acknowledgementsPlistPath: path)
     }
 
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
 
-    func commonInit(acknowledgementsPlistPath acknowledgementsPlistPath: String?, licenses: [String]?) {
+    func commonInit(acknowledgementsPlistPath acknowledgementsPlistPath: String?) {
         self.title = AcknowLocalization.localizedTitle()
 
         if let acknowledgementsPlistPath = acknowledgementsPlistPath {
@@ -121,16 +121,7 @@ public class AcknowListViewController: UITableViewController {
                 self.footerText = headerFooter.footer
             }
 
-            var acknowledgements = parser.parseAcknowledgements()
-            if let licenses = licenses {
-                acknowledgements = acknowledgements.filter { ack in
-                    if let license = ack.license {
-                        return licenses.contains(license)
-                    } else {
-                        return false
-                    }
-                }
-            }
+            let acknowledgements = parser.parseAcknowledgements()
             let sortedAcknowledgements = acknowledgements.sort({
                 (ack1: Acknow, ack2: Acknow) -> Bool in
                 let result = ack1.title.compare(
@@ -175,7 +166,7 @@ public class AcknowListViewController: UITableViewController {
         }
 
         if let path = path {
-            self.commonInit(acknowledgementsPlistPath: path, licenses: nil)
+            self.commonInit(acknowledgementsPlistPath: path)
         }
     }
 

--- a/Source/AcknowParser.swift
+++ b/Source/AcknowParser.swift
@@ -95,10 +95,11 @@ public class AcknowParser {
                     text = preferenceSpecifier["FooterText"] as! String? {
                         return Acknow(
                             title: title,
-                            text: text)
+                            text: text,
+                            license: preferenceSpecifier["License"] as? String)
                 }
                 else {
-                    return Acknow(title: "", text: "")
+                    return Acknow(title: "", text: "", license: "")
                 }
             })
 

--- a/Source/AcknowViewController.swift
+++ b/Source/AcknowViewController.swift
@@ -59,7 +59,7 @@ public class AcknowViewController: UIViewController {
      */
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        self.acknowledgement = Acknow(title: "", text: "")
+        self.acknowledgement = Acknow(title: "", text: "", license: nil)
     }
 
 

--- a/Tests/AcknowViewControllerTests.swift
+++ b/Tests/AcknowViewControllerTests.swift
@@ -14,7 +14,7 @@ import XCTest
 class AcknowViewControllerTests: XCTestCase {
 
     func testLoadView() {
-        let acknow = Acknow(title: "Title", text: "Text...")
+        let acknow = Acknow(title: "Title", text: "Text...", license: nil)
         let viewController = AcknowViewController(acknowledgement: acknow)
         viewController.loadView()
 


### PR DESCRIPTION
I added a feature which adds license types to acknowledgements.plist to CocoaPods (https://github.com/CocoaPods/CocoaPods/pull/5436). From 1.1.0.beta.1, the license type of each acknowledgements can be used. So, I want to filter acknowledgements by using this feature.