### PR TITLE
Use newer method for opening URLs when on iOS > 10

### DIFF
--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -242,11 +242,11 @@ open class AcknowListViewController: UITableViewController {
     @IBAction open func openCocoaPodsWebsite(_ sender: AnyObject) {
         let url = URL(string: AcknowLocalization.CocoaPodsURLString())
         if let url = url {
-			if #available(iOS 10.0, *) {
-				UIApplication.shared.open(url, options: [:], completionHandler: nil)
-			} else {
-				UIApplication.shared.openURL(url)
-			}
+            if #available(iOS 10.0, *) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            } else {
+                UIApplication.shared.openURL(url)
+            }
         }
     }
 

--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -242,7 +242,11 @@ open class AcknowListViewController: UITableViewController {
     @IBAction open func openCocoaPodsWebsite(_ sender: AnyObject) {
         let url = URL(string: AcknowLocalization.CocoaPodsURLString())
         if let url = url {
-            UIApplication.shared.openURL(url)
+			if #available(iOS 10.0, *) {
+				UIApplication.shared.open(url, options: [:], completionHandler: nil)
+			} else {
+				UIApplication.shared.openURL(url)
+			}
         }
     }
 


### PR DESCRIPTION
On iOS 10 or newer we should use the new method for opening URLs.