### PR TITLE
Move Done button to rightBarButtonItem

### DIFF
--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -197,7 +197,7 @@ open class AcknowListViewController: UITableViewController {
             if self.presentingViewController != nil &&
                 navigationController.viewControllers.first == self {
                 let item = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(AcknowListViewController.dismissViewController(_:)))
-                    self.navigationItem.leftBarButtonItem = item
+                    self.navigationItem.rightBarButtonItem = item
             }
         }
     }


### PR DESCRIPTION
In most apps, the "Done" or "Close" button is located at the top right corner of a navigation controller rather the top left corner (for example, the Notes app). I feel that it would be more intuitive to users to tap the Done button in the rightBarButtonItem position than the leftBarButtonItem position.