### PR TITLE
Add regex to filter out premature line breaks

### DIFF
--- a/AcknowList.podspec.json
+++ b/AcknowList.podspec.json
@@ -18,7 +18,7 @@
   "source_files": "Source/*.swift",
   "resources": "Resources/AcknowList.bundle",
   "platforms": {
-    "ios": "8.0",
+    "ios": "11.0",
     "tvos": "9.0"
   },
   "frameworks": "UIKit",

--- a/AcknowList.xcodeproj/project.pbxproj
+++ b/AcknowList.xcodeproj/project.pbxproj
@@ -412,6 +412,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.vtourraine.AcknowList;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -434,6 +435,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.vtourraine.AcknowList;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/AcknowExample.xcodeproj/project.pbxproj
+++ b/Example/AcknowExample.xcodeproj/project.pbxproj
@@ -415,7 +415,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AcknowExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.vtourraine.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -430,7 +430,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AcknowExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.vtourraine.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Source/AcknowViewController.swift
+++ b/Source/AcknowViewController.swift
@@ -60,9 +60,6 @@ open class AcknowViewController: UIViewController {
 
     // MARK: - View lifecycle
 
-    let TopBottomDefaultMargin: CGFloat = 20
-    let LeftRightDefaultMargin: CGFloat = 10
-
     /// Called after the controller's view is loaded into memory.
     open override func viewDidLoad() {
         super.viewDidLoad()
@@ -77,7 +74,15 @@ open class AcknowViewController: UIViewController {
             
             view.backgroundColor = UIColor.white
         #endif
-        textView.textContainerInset = UIEdgeInsetsMake(TopBottomDefaultMargin, LeftRightDefaultMargin, TopBottomDefaultMargin, LeftRightDefaultMargin)
+
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        let marginGuide = view.readableContentGuide
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: marginGuide.topAnchor),
+            textView.bottomAnchor.constraint(equalTo: marginGuide.bottomAnchor),
+            textView.leadingAnchor.constraint(equalTo: marginGuide.leadingAnchor),
+            textView.trailingAnchor.constraint(equalTo: marginGuide.trailingAnchor)])
+
         view.addSubview(textView)
 
         self.textView = textView
@@ -87,25 +92,9 @@ open class AcknowViewController: UIViewController {
     open override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        if let textView = textView {
-            updateTextViewInsets(textView)
-        }
-
         // Need to set the textView text after the layout is completed, so that the content inset and offset properties can be adjusted automatically.
         if let acknowledgement = self.acknowledgement {
             textView?.text = acknowledgement.text
         }
-    }
-
-    @available(iOS 11.0, tvOS 11.0, *) open override func viewLayoutMarginsDidChange() {
-        super.viewLayoutMarginsDidChange()
-
-        if let textView = textView {
-            updateTextViewInsets(textView)
-        }
-    }
-
-    func updateTextViewInsets(_ textView: UITextView) {
-        textView.textContainerInset = UIEdgeInsetsMake(TopBottomDefaultMargin, self.view.layoutMargins.left, TopBottomDefaultMargin, self.view.layoutMargins.right);
     }
 }

--- a/Source/AcknowViewController.swift
+++ b/Source/AcknowViewController.swift
@@ -74,6 +74,9 @@ open class AcknowViewController: UIViewController {
             
             view.backgroundColor = UIColor.white
         #endif
+        view.addSubview(textView)
+
+        self.textView = textView
 
         textView.translatesAutoresizingMaskIntoConstraints = false
         let marginGuide = view.readableContentGuide
@@ -82,10 +85,6 @@ open class AcknowViewController: UIViewController {
             textView.bottomAnchor.constraint(equalTo: marginGuide.bottomAnchor),
             textView.leadingAnchor.constraint(equalTo: marginGuide.leadingAnchor),
             textView.trailingAnchor.constraint(equalTo: marginGuide.trailingAnchor)])
-
-        view.addSubview(textView)
-
-        self.textView = textView
     }
 
     /// Called to notify the view controller that its view has just laid out its subviews.


### PR DESCRIPTION
This prevents text alignment issues, most visible on iPads, as in #41 