### PR TITLE
Added support for multiple plists.

### DIFF
--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -82,7 +82,12 @@ open class AcknowListViewController: UITableViewController {
     public init(acknowledgementsPlistPath: String?) {
         super.init(style: .grouped)
 
-        self.commonInit(acknowledgementsPlistPath: acknowledgementsPlistPath)
+        if let acknowledgementsPlistPath = acknowledgementsPlistPath {
+            self.commonInit(acknowledgementsPlistPaths: [acknowledgementsPlistPath])
+        }
+        else {
+            self.commonInit(acknowledgementsPlistPaths: [])
+        }
     }
     
     /**
@@ -110,19 +115,16 @@ open class AcknowListViewController: UITableViewController {
     public required init(coder aDecoder: NSCoder) {
         super.init(style: .grouped)
         let path = AcknowListViewController.defaultAcknowledgementsPlistPath()
-        self.commonInit(acknowledgementsPlistPath: path)
+        if let path = path {
+            self.commonInit(acknowledgementsPlistPaths: [path])
+        }
+        else {
+            self.commonInit(acknowledgementsPlistPaths: [])
+        }
     }
 
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-    }
-
-    func commonInit(acknowledgementsPlistPath: String?) {
-        if let path = acknowledgementsPlistPath {
-            commonInit(acknowledgementsPlistPaths: [path])
-        } else {
-            commonInit(acknowledgementsPlistPaths: [])
-        }
     }
 
     func commonInit(acknowledgementsPlistPaths: [String]) {
@@ -217,7 +219,7 @@ open class AcknowListViewController: UITableViewController {
         }
 
         if let path = path {
-            self.commonInit(acknowledgementsPlistPath: path)
+            self.commonInit(acknowledgementsPlistPaths: [path])
         }
     }
 

--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -89,19 +89,18 @@ open class AcknowListViewController: UITableViewController {
             self.commonInit(acknowledgementsPlistPaths: [])
         }
     }
-    
+
     /**
      Initializes the `AcknowListViewController` instance for a set of plist file paths.
-     
+
      The first path is the "main" one which will be used for any custom header/footer.
-     
+
      - parameter acknowledgementsPlistPaths: The paths to the acknowledgements plist files.
-     
+
      - returns: The new `AcknowListViewController` instance.
      */
     public init(acknowledgementsPlistPaths: [String]) {
         super.init(style: .grouped)
-        
         self.commonInit(acknowledgementsPlistPaths: acknowledgementsPlistPaths)
     }
 
@@ -129,14 +128,11 @@ open class AcknowListViewController: UITableViewController {
 
     func commonInit(acknowledgementsPlistPaths: [String]) {
         self.title = AcknowLocalization.localizedTitle()
-        
+
         guard !acknowledgementsPlistPaths.isEmpty else { return }
-        
-        // Parse the main plist source
-        var mainAcknowledgements = [Acknow]()
-        if let mainPath = acknowledgementsPlistPaths.first {
-            
-            let parser = AcknowParser(plistPath: mainPath)
+
+        if let mainPlistPath = acknowledgementsPlistPaths.first {
+            let parser = AcknowParser(plistPath: mainPlistPath)
             let headerFooter = parser.parseHeaderAndFooter()
 
             let DefaultHeaderText = "This application makes use of the following third party libraries:"
@@ -146,29 +142,25 @@ open class AcknowListViewController: UITableViewController {
             if (headerFooter.header == DefaultHeaderText) {
                 self.headerText = nil
             }
-            else if (headerFooter.header !=  "") {
+            else if (headerFooter.header != "") {
                 self.headerText = headerFooter.header
             }
 
-            if (headerFooter.footer == DefaultFooterText ||
-                headerFooter.footer == DefaultFooterTextLegacy) {
+            if (headerFooter.footer == DefaultFooterText || headerFooter.footer == DefaultFooterTextLegacy) {
                 self.footerText = AcknowLocalization.localizedCocoaPodsFooterText()
             }
             else if (headerFooter.footer != "") {
                 self.footerText = headerFooter.footer
             }
-            
-            mainAcknowledgements.append(contentsOf: parser.parseAcknowledgements())
         }
-        
-        // Parse any extra sources
-        for path in acknowledgementsPlistPaths.dropFirst() {
+
+        var acknowledgements: [Acknow] = []
+        for path in acknowledgementsPlistPaths {
             let parser = AcknowParser(plistPath: path)
-            mainAcknowledgements.append(contentsOf: parser.parseAcknowledgements())
+            acknowledgements.append(contentsOf: parser.parseAcknowledgements())
         }
-        
-        // Combine the sources and sort
-        let sortedAcknowledgements = mainAcknowledgements.sorted(by: {
+
+        let sortedAcknowledgements = acknowledgements.sorted(by: {
             (ack1: Acknow, ack2: Acknow) -> Bool in
             let result = ack1.title.compare(
                 ack2.title,

--- a/Tests/AcknowListViewControllerTests.swift
+++ b/Tests/AcknowListViewControllerTests.swift
@@ -3,7 +3,7 @@
 //  AcknowExample
 //
 //  Created by Vincent Tourraine on 22/08/15.
-//  Copyright © 2015-2017 Vincent Tourraine. All rights reserved.
+//  Copyright © 2015-2018 Vincent Tourraine. All rights reserved.
 //
 
 import UIKit
@@ -35,5 +35,23 @@ class AcknowListViewControllerTests: XCTestCase {
         XCTAssertEqual(viewController.acknowledgements?[0].title, "A title")
         XCTAssertEqual(viewController.acknowledgements?[1].title, "B title")
         XCTAssertEqual(viewController.acknowledgements?[2].title, "C title")
+    }
+
+    func testLoadFromMultiplePlist() {
+        let bundle = Bundle(for: AcknowListViewControllerTests.self)
+        let plistPath1 = bundle.path(forResource: "Pods-acknowledgements", ofType: "plist")
+        let plistPath2 = bundle.path(forResource: "Pods-acknowledgements-multi", ofType: "plist")
+
+        if let plistPath1 = plistPath1, let plistPath2 = plistPath2 {
+            let viewController = AcknowListViewController(acknowledgementsPlistPaths: [plistPath1, plistPath2])
+            XCTAssertEqual(viewController.acknowledgements?.count, 4)
+            XCTAssertEqual(viewController.acknowledgements?[0].title, "A title")
+            XCTAssertEqual(viewController.acknowledgements?[1].title, "AcknowList")
+            XCTAssertEqual(viewController.acknowledgements?[2].title, "B title")
+            XCTAssertEqual(viewController.acknowledgements?[3].title, "C title")
+        }
+        else {
+            XCTFail()
+        }
     }
 }


### PR DESCRIPTION
This allows you to provide more than one source to ultimately get merged and sorted into the list.
The first source is considered the "main" one, used to control any custom header/footer.

I found this useful in a project where there were acknowledgements required for sources that were manually integrated / not via Cocoapods. This allowed merging of the Cocoapods plist and an independently created one.