### PR TITLE
Extends functionality to figure out the Bundle Name

### DIFF
--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -179,15 +179,17 @@ open class AcknowListViewController: UITableViewController {
     }
     
     class func bundleName() -> String? {
-        var name: String?
-        
-        if let cfbundleName = Bundle.main.infoDictionary?["CFBundleName"] as? String {
-            name = cfbundleName
-        } else if let cfbundleExecutable = Bundle.main.infoDictionary?["CFBundleExecutable"] as? String {
-            name = cfbundleExecutable
+        let infoDictionary = Bundle.main.infoDictionary
+
+        if let cfBundleName = infoDictionary?["CFBundleName"] as? String {
+            return cfBundleName
         }
-        
-        return name
+        else if let cfBundleExecutable = infoDictionary?["CFBundleExecutable"] as? String {
+            return cfBundleExecutable
+        }
+        else {
+            return nil
+        }
     }
 
     class func defaultAcknowledgementsPlistPath() -> String? {

--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -177,9 +177,21 @@ open class AcknowListViewController: UITableViewController {
     class func acknowledgementsPlistPath(name:String) -> String? {
         return Bundle.main.path(forResource: name, ofType: "plist")
     }
+    
+    class func bundleName() -> String? {
+        var name: String?
+        
+        if let cfbundleName = Bundle.main.infoDictionary?["CFBundleName"] as? String {
+            name = cfbundleName
+        } else if let cfbundleExecutable = Bundle.main.infoDictionary?["CFBundleExecutable"] as? String {
+            name = cfbundleExecutable
+        }
+        
+        return name
+    }
 
     class func defaultAcknowledgementsPlistPath() -> String? {
-        guard let bundleName = Bundle.main.infoDictionary?["CFBundleName"] as? String else {
+        guard let bundleName = bundleName() else {
             return nil
         }
 


### PR DESCRIPTION
Hello,
I was trying to use the library and I saw that it wasn't finding the proper `plist`, even been with the proper name `Pods-{MyApp}-acknowledgements`.
Debugging I saw that the `CFBundleName` is empty in my App (probably because it is localized), so going deeper I saw that the `CFBundleExecutable` contains the value that I was looking for.

I have added a new function that by default search the `CFBundleName` field and if it is empty then go for `CFBundleExecutable`

Thanks!