### PR TITLE
Improvement with the UITableViewCells

### DIFF
--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -250,19 +250,6 @@ open class AcknowListViewController: UITableViewController {
     }
 
     /**
-     Notifies the view controller that its view is about to be added to a view hierarchy.
-
-     - parameter animated: If `YES`, the view is being added to the window using an animation.
-     */
-    open override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-
-        if let indexPath = self.tableView.indexPathForSelectedRow {
-            self.tableView.deselectRow(at: indexPath, animated: animated)
-        }
-    }
-
-    /**
      Notifies the view controller that its view was added to a view hierarchy.
 
      - parameter animated: If `YES`, the view is being added to the window using an animation.
@@ -455,6 +442,7 @@ open class AcknowListViewController: UITableViewController {
                 let viewController = AcknowViewController(acknowledgement: acknowledgement)
                 navigationController.pushViewController(viewController, animated: true)
         }
+        tableView.deselectRow(at: indexPath, animated: true)
     }
 
     /**

--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -232,7 +232,11 @@ open class AcknowListViewController: UITableViewController {
     /// Called after the controller's view is loaded into memory.
     open override func viewDidLoad() {
         super.viewDidLoad()
-
+        
+        // Register the cell before use it
+        let identifier = String(describing: UITableViewCell.self)
+        tableView.register(UITableViewCell.classForCoder(), forCellReuseIdentifier: identifier)
+        
         self.configureHeaderView()
         self.configureFooterView()
 
@@ -423,16 +427,9 @@ open class AcknowListViewController: UITableViewController {
      - returns: An object inheriting from `UITableViewCell` that the table view can use for the specified row. An assertion is raised if you return `nil`.
      */
     open override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let CellIdentifier = "Cell"
-        let dequeuedCell = tableView.dequeueReusableCell(withIdentifier: CellIdentifier)
-        let cell: UITableViewCell
-        if let dequeuedCell = dequeuedCell {
-            cell = dequeuedCell
-        }
-        else {
-            cell = UITableViewCell(style: UITableViewCell.CellStyle.default, reuseIdentifier: CellIdentifier)
-        }
-
+        let identifier = String(describing: UITableViewCell.self)
+        let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath)
+        
         if let acknowledgements = self.acknowledgements,
             let acknowledgement = acknowledgements[(indexPath as NSIndexPath).row] as Acknow?,
             let textLabel = cell.textLabel as UILabel? {

--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -250,6 +250,19 @@ open class AcknowListViewController: UITableViewController {
     }
 
     /**
+     Notifies the view controller that its view is about to be added to a view hierarchy.
+
+     - parameter animated: If `YES`, the view is being added to the window using an animation.
+     */
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        if let indexPath = self.tableView.indexPathForSelectedRow {
+            self.tableView.deselectRow(at: indexPath, animated: animated)
+        }
+    }
+
+    /**
      Notifies the view controller that its view was added to a view hierarchy.
 
      - parameter animated: If `YES`, the view is being added to the window using an animation.
@@ -442,7 +455,6 @@ open class AcknowListViewController: UITableViewController {
                 let viewController = AcknowViewController(acknowledgement: acknowledgement)
                 navigationController.pushViewController(viewController, animated: true)
         }
-        tableView.deselectRow(at: indexPath, animated: true)
     }
 
     /**


### PR DESCRIPTION
Hello, this PR make some improvements in the general use of the UITableVIew & UITableViewCells.

It improves 2 features: 

- It follows the recommended way by apple to reuse UITableViewCells, it is no longer needed to check if the cell was created previously.

- Deselect the cell after being selected, is not needed to thing tricky things in the `viewWillAppear` method.

Feel free to change/adapt to your guideline style.
Finally, remember also to update & release it in Cocoapods.

Thanks