### PR TITLE
Fix acknowledgement details not "scrollable" on tvOS

### DIFF
--- a/Source/AcknowViewController.swift
+++ b/Source/AcknowViewController.swift
@@ -76,6 +76,9 @@ open class AcknowViewController: UIViewController {
             textView.dataDetectorTypes = .link
             
             view.backgroundColor = UIColor.white
+        #elseif os(tvOS)
+            textView.isUserInteractionEnabled = true
+            textView.panGestureRecognizer.allowedTouchTypes = [NSNumber(value: UITouch.TouchType.indirect.rawValue)]
         #endif
         textView.textContainerInset = UIEdgeInsets.init(top: TopBottomDefaultMargin, left: LeftRightDefaultMargin, bottom: TopBottomDefaultMargin, right: LeftRightDefaultMargin)
         view.addSubview(textView)


### PR DESCRIPTION
Bugfix for issue #62 - enable scrolling for licenses if the length of the "FooterText" in Pods-acknowledgement.plist exceeds the screen height.
