### PR TITLE
Make all designated initializers in AcknowListViewController public

### DIFF
--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -122,10 +122,6 @@ open class AcknowListViewController: UITableViewController {
         }
     }
 
-    override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-    }
-
     func commonInit(acknowledgementsPlistPaths: [String]) {
         title = AcknowLocalization.localizedTitle()
 

--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -122,7 +122,7 @@ open class AcknowListViewController: UITableViewController {
         }
     }
 
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
 


### PR DESCRIPTION
`init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?)` initializer needs to be public in order for a subclass of `AcknowListViewController` to use the convenience initializer.

Xcode release notes: 

> Convenience initializer inheritance for subclasses defined outside the module that defines the base class now comes with additional restrictions. When these subclasses have a base class with non-public designated initializers, they no longer automatically inherit convenience initializers from their superclasses. To restore this automatic inheritance behavior, the base class must ensure that **all** of its designated initializers are public or open. (51249311)
 
https://developer.apple.com/documentation/xcode_release_notes/xcode_11_4_release_notes