### PR TITLE
Custom style

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/Example/AcknowExample/Base.lproj/Main.storyboard
+++ b/Example/AcknowExample/Base.lproj/Main.storyboard
@@ -1,8 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8173.3" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Nk8-2d-AXR">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Nk8-2d-AXR">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8142"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--AcknowList Example-->
@@ -14,30 +17,60 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MyE-DU-ync">
-                                <rect key="frame" x="197" y="285" width="207" height="30"/>
-                                <state key="normal" title="Push AcknowList (Storyboard)"/>
-                                <connections>
-                                    <segue destination="BsL-wc-ue5" kind="show" id="BEy-rK-1Bu"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Iqq-HF-drT">
-                                <rect key="frame" x="217" y="323" width="167" height="30"/>
-                                <state key="normal" title="Push AcknowList (Code)"/>
-                                <connections>
-                                    <action selector="pushAcknowList:" destination="BYZ-38-t0r" eventType="touchUpInside" id="sti-FP-FSd"/>
-                                </connections>
-                            </button>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jgi-Ed-Vrq">
+                                <rect key="frame" x="20" y="376" width="374" height="144"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MyE-DU-ync">
+                                        <rect key="frame" x="83" y="0.0" width="208" height="30"/>
+                                        <state key="normal" title="Push AcknowList (Storyboard)"/>
+                                        <connections>
+                                            <segue destination="BsL-wc-ue5" kind="show" id="BEy-rK-1Bu"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Iqq-HF-drT">
+                                        <rect key="frame" x="74" y="38" width="226" height="30"/>
+                                        <state key="normal" title="Push AcknowList (Code, Default)"/>
+                                        <connections>
+                                            <action selector="pushAcknowList:" destination="BYZ-38-t0r" eventType="touchUpInside" id="sti-FP-FSd"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EkS-ou-G13">
+                                        <rect key="frame" x="53" y="76" width="268" height="30"/>
+                                        <state key="normal" title="Push AcknowList (Code, Custom Style)"/>
+                                        <connections>
+                                            <action selector="pushAcknowListWithGroupedInsetStyle:" destination="BYZ-38-t0r" eventType="touchUpInside" id="vsV-0B-Sjl"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qnQ-ut-L6B">
+                                        <rect key="frame" x="55.5" y="114" width="263" height="30"/>
+                                        <state key="normal" title="Push AcknowList (Code, Custom Title)"/>
+                                        <connections>
+                                            <action selector="pushAcknowListWithCustomTitle:" destination="BYZ-38-t0r" eventType="touchUpInside" id="C8y-JO-DMk"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstItem="MyE-DU-ync" firstAttribute="top" secondItem="Jgi-Ed-Vrq" secondAttribute="top" id="DfS-r9-qzE"/>
+                                    <constraint firstItem="MyE-DU-ync" firstAttribute="centerX" secondItem="Jgi-Ed-Vrq" secondAttribute="centerX" id="Jfy-T0-iCX"/>
+                                    <constraint firstItem="Iqq-HF-drT" firstAttribute="top" secondItem="MyE-DU-ync" secondAttribute="bottom" constant="8" id="Yhn-up-lSa"/>
+                                    <constraint firstItem="qnQ-ut-L6B" firstAttribute="centerX" secondItem="EkS-ou-G13" secondAttribute="centerX" id="gUo-mL-30p"/>
+                                    <constraint firstItem="EkS-ou-G13" firstAttribute="centerX" secondItem="Iqq-HF-drT" secondAttribute="centerX" id="lMN-Af-eb3"/>
+                                    <constraint firstItem="EkS-ou-G13" firstAttribute="top" secondItem="Iqq-HF-drT" secondAttribute="bottom" constant="8" id="oKF-0k-B57"/>
+                                    <constraint firstAttribute="bottom" secondItem="qnQ-ut-L6B" secondAttribute="bottom" id="q7f-5D-CbP"/>
+                                    <constraint firstItem="qnQ-ut-L6B" firstAttribute="top" secondItem="EkS-ou-G13" secondAttribute="bottom" constant="8" id="yGf-f9-yOO"/>
+                                    <constraint firstItem="Iqq-HF-drT" firstAttribute="centerX" secondItem="MyE-DU-ync" secondAttribute="centerX" id="yng-6x-vo9"/>
+                                </constraints>
+                            </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="MyE-DU-ync" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="OZ4-Xg-jHw"/>
-                            <constraint firstItem="Iqq-HF-drT" firstAttribute="top" secondItem="MyE-DU-ync" secondAttribute="bottom" constant="8" id="OuL-Zn-7Hh"/>
-                            <constraint firstItem="Iqq-HF-drT" firstAttribute="centerX" secondItem="MyE-DU-ync" secondAttribute="centerX" id="hcb-ZH-iEe"/>
-                            <constraint firstItem="MyE-DU-ync" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="q5f-IP-jBy"/>
+                            <constraint firstItem="Jgi-Ed-Vrq" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="M1x-nZ-gKC"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="Jgi-Ed-Vrq" secondAttribute="trailing" id="dMK-Pz-cGj"/>
+                            <constraint firstItem="Jgi-Ed-Vrq" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="y7A-4x-GOB"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="AcknowList Example" id="xIb-0L-dfj"/>
@@ -55,10 +88,11 @@
                         <viewControllerLayoutGuide type="bottom" id="3ZD-2v-pKl"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="msB-b3-294">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
+                    <navigationItem key="navigationItem" id="BP3-Ce-X6N"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="string" keyPath="acknowledgementsPlistName" value="Pods-AcknowExample-acknowledgements"/>
                     </userDefinedRuntimeAttributes>
@@ -73,7 +107,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Nk8-2d-AXR" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="KgB-Of-Qia">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -86,4 +120,9 @@
             <point key="canvasLocation" x="58" y="1010"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Example/AcknowExample/Base.lproj/Main.storyboard
+++ b/Example/AcknowExample/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Nk8-2d-AXR">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina3_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
@@ -17,38 +17,38 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jgi-Ed-Vrq">
-                                <rect key="frame" x="20" y="376" width="374" height="144"/>
+                                <rect key="frame" x="16" y="168" width="288" height="144"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MyE-DU-ync">
-                                        <rect key="frame" x="83" y="0.0" width="208" height="30"/>
+                                        <rect key="frame" x="40" y="0.0" width="208" height="30"/>
                                         <state key="normal" title="Push AcknowList (Storyboard)"/>
                                         <connections>
                                             <segue destination="BsL-wc-ue5" kind="show" id="BEy-rK-1Bu"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Iqq-HF-drT">
-                                        <rect key="frame" x="74" y="38" width="226" height="30"/>
-                                        <state key="normal" title="Push AcknowList (Code, Default)"/>
+                                        <rect key="frame" x="12" y="38" width="264" height="30"/>
+                                        <state key="normal" title="Push AcknowList (Code, Default Style)"/>
                                         <connections>
-                                            <action selector="pushAcknowList:" destination="BYZ-38-t0r" eventType="touchUpInside" id="sti-FP-FSd"/>
+                                            <action selector="pushAcknowListWithCustomTitleDefaultStyle:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uqg-nD-Yg9"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EkS-ou-G13">
-                                        <rect key="frame" x="53" y="76" width="268" height="30"/>
-                                        <state key="normal" title="Push AcknowList (Code, Custom Style)"/>
+                                        <rect key="frame" x="20" y="76" width="248" height="30"/>
+                                        <state key="normal" title="Push AcknowList (Code, Plain Style)"/>
                                         <connections>
-                                            <action selector="pushAcknowListWithGroupedInsetStyle:" destination="BYZ-38-t0r" eventType="touchUpInside" id="vsV-0B-Sjl"/>
+                                            <action selector="pushAcknowListWithCustomTitlePlainStyle:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7Lu-jt-8bG"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qnQ-ut-L6B">
-                                        <rect key="frame" x="55.5" y="114" width="263" height="30"/>
-                                        <state key="normal" title="Push AcknowList (Code, Custom Title)"/>
+                                        <rect key="frame" x="-12" y="114" width="312" height="30"/>
+                                        <state key="normal" title="Push AcknowList (Code, Inset Grouped Style)"/>
                                         <connections>
-                                            <action selector="pushAcknowListWithCustomTitle:" destination="BYZ-38-t0r" eventType="touchUpInside" id="C8y-JO-DMk"/>
+                                            <action selector="pushAcknowListWithCustomTitleInsetGroupedStyle:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1Lt-Uj-eaq"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -88,7 +88,7 @@
                         <viewControllerLayoutGuide type="bottom" id="3ZD-2v-pKl"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="msB-b3-294">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
@@ -107,7 +107,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Nk8-2d-AXR" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="KgB-Of-Qia">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/Example/AcknowExample/ViewController.swift
+++ b/Example/AcknowExample/ViewController.swift
@@ -26,25 +26,31 @@ import UIKit
 import AcknowList
 
 class ViewController: UIViewController {
-
+    
     @IBAction func pushAcknowList(_ sender: AnyObject) {
         let viewController = AcknowListViewController(fileNamed: "Pods-acknowledgements")
         viewController.headerText = "Visit: https://developer.apple.com"
         navigationController?.pushViewController(viewController, animated: true)
     }
-
-    @IBAction func pushAcknowListWithGroupedInsetStyle(_ sender: AnyObject) {
+    
+    @IBAction func pushAcknowListWithCustomTitleDefaultStyle(_ sender: AnyObject) {
+        let viewController = AcknowListViewController(fileNamed: "Pods-acknowledgements")
+        viewController.title = "Default Style"
+        viewController.headerText = "Visit: https://developer.apple.com"
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+    
+    @IBAction func pushAcknowListWithCustomTitlePlainStyle(_ sender: AnyObject) {
+        let viewController = AcknowListViewController(fileNamed: "Pods-acknowledgements", style: .plain)
+        viewController.title = "Plain Style"
+        viewController.headerText = "Visit: https://developer.apple.com"
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+    
+    @IBAction func pushAcknowListWithCustomTitleInsetGroupedStyle(_ sender: AnyObject) {
         if #available(iOS 13.0, *) {
             let viewController = AcknowListViewController(fileNamed: "Pods-acknowledgements", style: .insetGrouped)
-            viewController.headerText = "Visit: https://developer.apple.com"
-            navigationController?.pushViewController(viewController, animated: true)
-        }
-        return
-    }
-
-    @IBAction func pushAcknowListWithCustomTitle(_ sender: AnyObject) {
-        if #available(iOS 13.0, *) {
-            let viewController = AcknowListViewController(fileNamed: "Pods-acknowledgements", customTitle: "Custom Title")
+            viewController.title = "Grouped Inset Style"
             viewController.headerText = "Visit: https://developer.apple.com"
             navigationController?.pushViewController(viewController, animated: true)
         }

--- a/Example/AcknowExample/ViewController.swift
+++ b/Example/AcknowExample/ViewController.swift
@@ -32,4 +32,22 @@ class ViewController: UIViewController {
         viewController.headerText = "Visit: https://developer.apple.com"
         navigationController?.pushViewController(viewController, animated: true)
     }
+
+    @IBAction func pushAcknowListWithGroupedInsetStyle(_ sender: AnyObject) {
+        if #available(iOS 13.0, *) {
+            let viewController = AcknowListViewController(fileNamed: "Pods-acknowledgements", style: .insetGrouped)
+            viewController.headerText = "Visit: https://developer.apple.com"
+            navigationController?.pushViewController(viewController, animated: true)
+        }
+        return
+    }
+
+    @IBAction func pushAcknowListWithCustomTitle(_ sender: AnyObject) {
+        if #available(iOS 13.0, *) {
+            let viewController = AcknowListViewController(fileNamed: "Pods-acknowledgements", customTitle: "Custom Title")
+            viewController.headerText = "Visit: https://developer.apple.com"
+            navigationController?.pushViewController(viewController, animated: true)
+        }
+        return
+    }
 }

--- a/Example/AcknowExample/ViewController.swift
+++ b/Example/AcknowExample/ViewController.swift
@@ -26,13 +26,7 @@ import UIKit
 import AcknowList
 
 class ViewController: UIViewController {
-    
-    @IBAction func pushAcknowList(_ sender: AnyObject) {
-        let viewController = AcknowListViewController(fileNamed: "Pods-acknowledgements")
-        viewController.headerText = "Visit: https://developer.apple.com"
-        navigationController?.pushViewController(viewController, animated: true)
-    }
-    
+
     @IBAction func pushAcknowListWithCustomTitleDefaultStyle(_ sender: AnyObject) {
         let viewController = AcknowListViewController(fileNamed: "Pods-acknowledgements")
         viewController.title = "Default Style"
@@ -41,7 +35,8 @@ class ViewController: UIViewController {
     }
     
     @IBAction func pushAcknowListWithCustomTitlePlainStyle(_ sender: AnyObject) {
-        let viewController = AcknowListViewController(fileNamed: "Pods-acknowledgements", style: .plain)
+        let path = Bundle.main.path(forResource: "Pods-acknowledgements", ofType: "plist")
+        let viewController = AcknowListViewController(acknowledgementsPlistPath: path, style: .plain)
         viewController.title = "Plain Style"
         viewController.headerText = "Visit: https://developer.apple.com"
         navigationController?.pushViewController(viewController, animated: true)
@@ -49,7 +44,8 @@ class ViewController: UIViewController {
     
     @IBAction func pushAcknowListWithCustomTitleInsetGroupedStyle(_ sender: AnyObject) {
         if #available(iOS 13.0, *) {
-            let viewController = AcknowListViewController(fileNamed: "Pods-acknowledgements", style: .insetGrouped)
+            let path = Bundle.main.path(forResource: "Pods-acknowledgements", ofType: "plist")
+            let viewController = AcknowListViewController(acknowledgementsPlistPath: path, style: .insetGrouped)
             viewController.title = "Grouped Inset Style"
             viewController.headerText = "Visit: https://developer.apple.com"
             navigationController?.pushViewController(viewController, animated: true)

--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -57,9 +57,9 @@ open class AcknowListViewController: UITableViewController {
 
      - returns: The new `AcknowListViewController` instance.
      */
-    public convenience init(style: UITableView.Style = .grouped, customTitle: String? = nil) {
+    public override convenience init(style: UITableView.Style = .grouped) {
         let path = AcknowListViewController.defaultAcknowledgementsPlistPath()
-        self.init(acknowledgementsPlistPath: path, style: style, customTitle: customTitle)
+        self.init(acknowledgementsPlistPath: path, style: style)
     }
 
     /**
@@ -67,9 +67,9 @@ open class AcknowListViewController: UITableViewController {
 
      - returns: The new `AcknowListViewController` instance.
      */
-    public convenience init(fileNamed fileName: String, style: UITableView.Style = .grouped, customTitle: String? = nil) {
+    public convenience init(fileNamed fileName: String, style: UITableView.Style = .grouped) {
         let path = AcknowListViewController.acknowledgementsPlistPath(name: fileName)
-        self.init(acknowledgementsPlistPath: path, style: style, customTitle: customTitle)
+        self.init(acknowledgementsPlistPath: path, style: style)
     }
 
     /**
@@ -79,14 +79,14 @@ open class AcknowListViewController: UITableViewController {
 
      - returns: The new `AcknowListViewController` instance.
      */
-    public init(acknowledgementsPlistPath: String?, style: UITableView.Style = .grouped, customTitle: String? = nil) {
+    public init(acknowledgementsPlistPath: String?, style: UITableView.Style = .grouped) {
         super.init(style: style)
 
         if let acknowledgementsPlistPath = acknowledgementsPlistPath {
-            commonInit(acknowledgementsPlistPaths: [acknowledgementsPlistPath], customTitle: customTitle)
+            commonInit(acknowledgementsPlistPaths: [acknowledgementsPlistPath])
         }
         else {
-            commonInit(acknowledgementsPlistPaths: [], customTitle: customTitle)
+            commonInit(acknowledgementsPlistPaths: [])
         }
     }
 
@@ -99,9 +99,9 @@ open class AcknowListViewController: UITableViewController {
 
      - returns: The new `AcknowListViewController` instance.
      */
-    public init(acknowledgementsPlistPaths: [String], style: UITableView.Style = .grouped, customTitle: String? = nil) {
+    public init(acknowledgementsPlistPaths: [String], style: UITableView.Style = .grouped) {
         super.init(style: style)
-        commonInit(acknowledgementsPlistPaths: acknowledgementsPlistPaths, customTitle: customTitle)
+        commonInit(acknowledgementsPlistPaths: acknowledgementsPlistPaths)
     }
 
     /**
@@ -122,9 +122,7 @@ open class AcknowListViewController: UITableViewController {
         }
     }
 
-    func commonInit(acknowledgementsPlistPaths: [String], customTitle: String? = nil) {
-        title = customTitle ?? AcknowLocalization.localizedTitle()
-
+    func commonInit(acknowledgementsPlistPaths: [String]) {
         guard !acknowledgementsPlistPaths.isEmpty else { return }
 
         if let mainPlistPath = acknowledgementsPlistPaths.first {

--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -57,9 +57,9 @@ open class AcknowListViewController: UITableViewController {
 
      - returns: The new `AcknowListViewController` instance.
      */
-    public convenience init() {
+    public convenience init(style: UITableView.Style = .grouped, customTitle: String? = nil) {
         let path = AcknowListViewController.defaultAcknowledgementsPlistPath()
-        self.init(acknowledgementsPlistPath: path)
+        self.init(acknowledgementsPlistPath: path, style: style, customTitle: customTitle)
     }
 
     /**
@@ -67,9 +67,9 @@ open class AcknowListViewController: UITableViewController {
 
      - returns: The new `AcknowListViewController` instance.
      */
-    public convenience init(fileNamed fileName: String) {
+    public convenience init(fileNamed fileName: String, style: UITableView.Style = .grouped, customTitle: String? = nil) {
         let path = AcknowListViewController.acknowledgementsPlistPath(name: fileName)
-        self.init(acknowledgementsPlistPath: path)
+        self.init(acknowledgementsPlistPath: path, style: style, customTitle: customTitle)
     }
 
     /**
@@ -79,14 +79,14 @@ open class AcknowListViewController: UITableViewController {
 
      - returns: The new `AcknowListViewController` instance.
      */
-    public init(acknowledgementsPlistPath: String?) {
-        super.init(style: .grouped)
+    public init(acknowledgementsPlistPath: String?, style: UITableView.Style = .grouped, customTitle: String? = nil) {
+        super.init(style: style)
 
         if let acknowledgementsPlistPath = acknowledgementsPlistPath {
-            commonInit(acknowledgementsPlistPaths: [acknowledgementsPlistPath])
+            commonInit(acknowledgementsPlistPaths: [acknowledgementsPlistPath], customTitle: customTitle)
         }
         else {
-            commonInit(acknowledgementsPlistPaths: [])
+            commonInit(acknowledgementsPlistPaths: [], customTitle: customTitle)
         }
     }
 
@@ -99,9 +99,9 @@ open class AcknowListViewController: UITableViewController {
 
      - returns: The new `AcknowListViewController` instance.
      */
-    public init(acknowledgementsPlistPaths: [String]) {
-        super.init(style: .grouped)
-        commonInit(acknowledgementsPlistPaths: acknowledgementsPlistPaths)
+    public init(acknowledgementsPlistPaths: [String], style: UITableView.Style = .grouped, customTitle: String? = nil) {
+        super.init(style: style)
+        commonInit(acknowledgementsPlistPaths: acknowledgementsPlistPaths, customTitle: customTitle)
     }
 
     /**
@@ -122,8 +122,8 @@ open class AcknowListViewController: UITableViewController {
         }
     }
 
-    func commonInit(acknowledgementsPlistPaths: [String]) {
-        title = AcknowLocalization.localizedTitle()
+    func commonInit(acknowledgementsPlistPaths: [String], customTitle: String? = nil) {
+        title = customTitle ?? AcknowLocalization.localizedTitle()
 
         guard !acknowledgementsPlistPaths.isEmpty else { return }
 

--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -134,6 +134,8 @@ open class AcknowListViewController: UITableViewController {
     }
 
     func commonInit(acknowledgementsPlistPaths: [String]) {
+        title = AcknowLocalization.localizedTitle()
+
         guard !acknowledgementsPlistPaths.isEmpty else { return }
 
         if let mainPlistPath = acknowledgementsPlistPaths.first {

--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -49,20 +49,16 @@ open class AcknowListViewController: UITableViewController {
      */
     @IBInspectable var acknowledgementsPlistName: String?
 
-
     // MARK: - Initialization
 
     /**
      Initializes the `AcknowListViewController` instance based on default configuration.
 
-     - Parameters:
-        - style: UITableView.Style to apply to the table view. **Default:** `.grouped`
-
      - returns: The new `AcknowListViewController` instance.
      */
-    public override convenience init(style: UITableView.Style = .grouped) {
+    public convenience init() {
         let path = AcknowListViewController.defaultAcknowledgementsPlistPath()
-        self.init(acknowledgementsPlistPath: path, style: style)
+        self.init(acknowledgementsPlistPath: path)
     }
 
     /**
@@ -70,13 +66,12 @@ open class AcknowListViewController: UITableViewController {
 
      - Parameters:
        - fileNamed: Name of the acknowledgements plist file
-       - style: `UITableView.Style` to apply to the table view. **Default:** `.grouped`
 
      - returns: The new `AcknowListViewController` instance.
      */
-    public convenience init(fileNamed fileName: String, style: UITableView.Style = .grouped) {
+    public convenience init(fileNamed fileName: String) {
         let path = AcknowListViewController.acknowledgementsPlistPath(name: fileName)
-        self.init(acknowledgementsPlistPath: path, style: style)
+        self.init(acknowledgementsPlistPath: path)
     }
 
     /**

--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -49,6 +49,7 @@ open class AcknowListViewController: UITableViewController {
      */
     @IBInspectable var acknowledgementsPlistName: String?
 
+
     // MARK: - Initialization
 
     /**

--- a/Source/AcknowListViewController.swift
+++ b/Source/AcknowListViewController.swift
@@ -55,6 +55,9 @@ open class AcknowListViewController: UITableViewController {
     /**
      Initializes the `AcknowListViewController` instance based on default configuration.
 
+     - Parameters:
+        - style: UITableView.Style to apply to the table view. **Default:** `.grouped`
+
      - returns: The new `AcknowListViewController` instance.
      */
     public override convenience init(style: UITableView.Style = .grouped) {
@@ -64,6 +67,10 @@ open class AcknowListViewController: UITableViewController {
 
     /**
      Initializes the `AcknowListViewController` instance for the plist file based on its name.
+
+     - Parameters:
+       - fileNamed: Name of the acknowledgements plist file
+       - style: `UITableView.Style` to apply to the table view. **Default:** `.grouped`
 
      - returns: The new `AcknowListViewController` instance.
      */
@@ -75,7 +82,9 @@ open class AcknowListViewController: UITableViewController {
     /**
      Initializes the `AcknowListViewController` instance for a plist file path.
 
-     - parameter acknowledgementsPlistPath: The path to the acknowledgements plist file.
+     - Parameters:
+        - acknowledgementsPlistPath: The path to the acknowledgements plist file.
+        - style: `UITableView.Style` to apply to the table view. **Default:** `.grouped`
 
      - returns: The new `AcknowListViewController` instance.
      */
@@ -95,7 +104,9 @@ open class AcknowListViewController: UITableViewController {
 
      The first path is the "main" one which will be used for any custom header/footer.
 
-     - parameter acknowledgementsPlistPaths: The paths to the acknowledgements plist files.
+     - Parameters:
+        - acknowledgementsPlistPaths: The paths to the acknowledgements plist files.
+        - style: `UITableView.Style` to apply to the table view. **Default:** `.grouped`
 
      - returns: The new `AcknowListViewController` instance.
      */

--- a/Tests/AcknowListViewControllerTests.swift
+++ b/Tests/AcknowListViewControllerTests.swift
@@ -26,20 +26,6 @@ class AcknowListViewControllerTests: XCTestCase {
         XCTAssertEqual(cell.textLabel?.text, "AcknowList")
     }
 
-    func testConfigureTableViewWithCustomTitle() {
-        let bundle = Bundle(for: AcknowListViewControllerTests.self)
-        let plistPath = bundle.path(forResource: "Pods-acknowledgements", ofType: "plist")
-
-        let viewController = AcknowListViewController(acknowledgementsPlistPath: plistPath, customTitle: "Custom Title")
-
-        XCTAssertEqual(viewController.numberOfSections(in: viewController.tableView), 1)
-        XCTAssertEqual(viewController.tableView(viewController.tableView, numberOfRowsInSection: 0), 1)
-        XCTAssertEqual(viewController.title, "Custom Title")
-
-        let cell = viewController.tableView(viewController.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
-        XCTAssertEqual(cell.textLabel?.text, "AcknowList")
-    }
-
     @available (iOS 13.0, *)
     func testConfigureTableViewWithCustomStyle() {
         let bundle = Bundle(for: AcknowListViewControllerTests.self)

--- a/Tests/AcknowListViewControllerTests.swift
+++ b/Tests/AcknowListViewControllerTests.swift
@@ -26,6 +26,35 @@ class AcknowListViewControllerTests: XCTestCase {
         XCTAssertEqual(cell.textLabel?.text, "AcknowList")
     }
 
+    func testConfigureTableViewWithCustomTitle() {
+        let bundle = Bundle(for: AcknowListViewControllerTests.self)
+        let plistPath = bundle.path(forResource: "Pods-acknowledgements", ofType: "plist")
+
+        let viewController = AcknowListViewController(acknowledgementsPlistPath: plistPath, customTitle: "Custom Title")
+
+        XCTAssertEqual(viewController.numberOfSections(in: viewController.tableView), 1)
+        XCTAssertEqual(viewController.tableView(viewController.tableView, numberOfRowsInSection: 0), 1)
+        XCTAssertEqual(viewController.title, "Custom Title")
+
+        let cell = viewController.tableView(viewController.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+        XCTAssertEqual(cell.textLabel?.text, "AcknowList")
+    }
+
+    @available (iOS 13.0, *)
+    func testConfigureTableViewWithCustomStyle() {
+        let bundle = Bundle(for: AcknowListViewControllerTests.self)
+        let plistPath = bundle.path(forResource: "Pods-acknowledgements", ofType: "plist")
+
+        let viewController = AcknowListViewController(acknowledgementsPlistPath: plistPath, style: .insetGrouped)
+
+        XCTAssertEqual(viewController.numberOfSections(in: viewController.tableView), 1)
+        XCTAssertEqual(viewController.tableView(viewController.tableView, numberOfRowsInSection: 0), 1)
+        XCTAssertEqual(viewController.tableView.style, .insetGrouped)
+
+        let cell = viewController.tableView(viewController.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+        XCTAssertEqual(cell.textLabel?.text, "AcknowList")
+    }
+
     func testSortsAcknowledgementsByTitle() {
         let bundle = Bundle(for: AcknowListViewControllerTests.self)
         let plistPath = bundle.path(forResource: "Pods-acknowledgements-multi", ofType: "plist")

--- a/Tests/AcknowListViewControllerTests.swift
+++ b/Tests/AcknowListViewControllerTests.swift
@@ -32,13 +32,7 @@ class AcknowListViewControllerTests: XCTestCase {
         let plistPath = bundle.path(forResource: "Pods-acknowledgements", ofType: "plist")
 
         let viewController = AcknowListViewController(acknowledgementsPlistPath: plistPath, style: .insetGrouped)
-
-        XCTAssertEqual(viewController.numberOfSections(in: viewController.tableView), 1)
-        XCTAssertEqual(viewController.tableView(viewController.tableView, numberOfRowsInSection: 0), 1)
         XCTAssertEqual(viewController.tableView.style, .insetGrouped)
-
-        let cell = viewController.tableView(viewController.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
-        XCTAssertEqual(cell.textLabel?.text, "AcknowList")
     }
 
     func testSortsAcknowledgementsByTitle() {

--- a/Tests/AcknowListViewControllerTests.swift
+++ b/Tests/AcknowListViewControllerTests.swift
@@ -19,6 +19,8 @@ class AcknowListViewControllerTests: XCTestCase {
 
         let viewController = AcknowListViewController(acknowledgementsPlistPath: plistPath)
 
+        XCTAssertEqual(viewController.tableView.style, .grouped, "should use `.grouped` as the default table view style")
+
         XCTAssertEqual(viewController.numberOfSections(in: viewController.tableView), 1)
         XCTAssertEqual(viewController.tableView(viewController.tableView, numberOfRowsInSection: 0), 1)
 


### PR DESCRIPTION
The purpose of this PR is to provide users with the capacity to expose the default table view style with any valid `UITableView.Style` option, and to provide a custom title for the presented view controller:

- `UITableViewController` accepts a `UITableView.Style` property in one of it's initialisers. This change allows a user to override the default `.grouped` with either `.plain` or `.insetGrouped` (available on iOS/iPad OS 13.0 +) to match their app's UI design when instantiating a new `AcknowListViewController`
- In some instances users may wish to override the default localized title "Acknowledgements" with a custom title. This change allows users to do so when instantiating a new `AcknowListViewController`