### PR TITLE
Fix the crash on iOS 15 using Xcode 13 RC #89

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "AcknowList",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v9), .tvOS(.v9), watchOS(.v7), macOS(.v10_15)
+        .iOS(.v9), .tvOS(.v9), .watchOS(.v7), .macOS(.v10_15)
     ],
     products: [
         .library(name: "AcknowList", targets: ["AcknowList"])

--- a/Sources/AcknowList/Acknow.swift
+++ b/Sources/AcknowList/Acknow.swift
@@ -21,10 +21,35 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import Foundation
 
 /// Represents a single acknowledgement.
 public struct Acknow {
 
+    /// The acknowledgement title (for instance: the pod’s name).
+    public let title: String
+
+    /// The acknowledgement body text (for instance: the pod’s license).
+    public let text: String
+
+    /// The acknowledgement license (for instance the pod’s license type).
+    public let license: String?
+
+    /// Returns an object initialized from the given parameters.
+    ///
+    /// - Parameters:
+    ///   - title: The acknowledgement title (for instance: the pod’s name).
+    ///   - text: The acknowledgement body text (for instance: the pod’s license).
+    ///   - license: The acknowledgement license (for instance the pod’s license type).
+    public init(title: String, text: String, license: String? = nil) {
+        self.title = title
+        self.text = text
+        self.license = license
+    }
+}
+
+@objc public class AcknowClass: NSObject {
+    
     /// The acknowledgement title (for instance: the pod’s name).
     public let title: String
 

--- a/Sources/AcknowList/AcknowListViewController.swift
+++ b/Sources/AcknowList/AcknowListViewController.swift
@@ -59,7 +59,7 @@ open class AcknowListViewController: UITableViewController {
 
      - returns: The new `AcknowListViewController` instance.
      */
-    public convenience init() {
+    @objc public convenience init() {
         if let path = AcknowListViewController.defaultAcknowledgementsPlistPath() {
             self.init(plistPath: path)
         }
@@ -114,11 +114,13 @@ open class AcknowListViewController: UITableViewController {
 
      - returns: The new `AcknowListViewController` instance.
      */
-    public convenience init(acknowledgements: [Acknow], style: UITableView.Style = .grouped) {
+    @objc public convenience init(acknowledgements: [AcknowClass], style: UITableView.Style = .grouped) {
         
         self.init(style: style)
-        
-        self.acknowledgements = acknowledgements
+
+        self.acknowledgements = acknowledgements.map { acknow in
+            Acknow(title: acknow.title, text: acknow.text, license: acknow.license)
+        }
 
         self.title = AcknowLocalization.localizedTitle()
     }

--- a/Sources/AcknowList/AcknowListViewController.swift
+++ b/Sources/AcknowList/AcknowListViewController.swift
@@ -114,12 +114,27 @@ open class AcknowListViewController: UITableViewController {
 
      - returns: The new `AcknowListViewController` instance.
      */
-    public init(acknowledgements: [Acknow], style: UITableView.Style = .grouped) {
+    public convenience init(acknowledgements: [Acknow], style: UITableView.Style = .grouped) {
+        
+        self.init(style: style)
+        
         self.acknowledgements = acknowledgements
 
-        super.init(style: style)
-
         self.title = AcknowLocalization.localizedTitle()
+    }
+    
+    /**
+     Bugfix for [Issue #89](https://github.com/vtourraine/AcknowList/issues/89).
+     
+     On iOS 15 using Xcode 13 RC, the initializer will crash unless this one is overridden.
+     
+     Solution taken from [StackOverflow](https://stackoverflow.com/questions/69092599/xcode-13-beta-5-error-uiviewcontroller-is-missing-its-initial-trait-collection)
+     */
+    public override init(style: UITableView.Style) {
+        
+        self.acknowledgements = []
+        
+        super.init(style: style)
     }
 
     /**


### PR DESCRIPTION
I described my changes in detail in https://github.com/vtourraine/AcknowList/issues/89.

It is probably a bug that will be fixed in later Xcode versions - some problems with the initializers not visible to objc. However, for now, I got it resolved using this: https://stackoverflow.com/questions/69092599/xcode-13-beta-5-error-uiviewcontroller-is-missing-its-initial-trait-collection

Ok, so I tried my solution, but it turned out that your last convenience initializer that finally calls super.init(style:) uses an array of Acknow, which is a struct. Therefore, this initializer cannot be exposed to `@objc`. 

The solution is to expose all convenience initializers to `@objc` and then overriding `init(style:)`, like this:
```
/**
Bugfix for [Issue #89](https://github.com/vtourraine/AcknowList/issues/89).
     
On iOS 15 using Xcode 13 RC, the initializer will crash unless this one is overridden.
     
Solution taken from [StackOverflow](https://stackoverflow.com/questions/69092599/xcode-13-beta-5-error-uiviewcontroller-is-missing-its-initial-trait-collection)
*/
public override init(style: UITableView.Style) {
        
   self.acknowledgements = []
        
   super.init(style: style)
}
```

And then calling `self.init(style: style)` in the convenience initializer instead of `super.init(style: style)`:

```
@objc public convenience init(acknowledgements: [Acknow], style: UITableView.Style = .grouped) {
        
   self.init(style: style)

   self.acknowledgements = acknowledgements

   self.title = AcknowLocalization.localizedTitle()
}
```

It seems to be your only solution for now is to remove the above convenience initializer, which means acknowledgements have to be set after initialization. Or hope that Apple fixes this annoying bug anytime soon.

I fixed the problem, but it is hacky and breaks the standard initializer, so all projects using it have to be updated slightly: 

Duplicate `Acknow` as a class inheriting from `NSObject`, thus exposing it to `@objc`. Then replace the `struct Acknow` array in the initializer with the `class Acknow` array and create a `struct Acknow` array by copying the values.