### PR TITLE
Fix open URL on macOS with SwiftUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `GitHubAPI` to get licenses from GitHub API
 - Update `AcknowListViewController` to get missing licenses from GitHub API, with new `canFetchLicenseFromGitHub` property to disable this behavior
+- Fix open URL on macOS with SwiftUI
 
 
 ## 3.0.1 (24 November 2022)

--- a/Sources/AcknowList/AcknowListSwiftUI.swift
+++ b/Sources/AcknowList/AcknowListSwiftUI.swift
@@ -126,7 +126,9 @@ public struct AcknowListRowSwiftUIView: View {
         else if let repository = acknowledgement.repository,
                 canOpenRepository(for: repository) {
             Button(action: {
-#if os(iOS)
+#if os(macOS)
+                NSWorkspace.shared.open(repository)
+#elseif os(iOS)
                 UIApplication.shared.open(repository)
 #endif
             }) {


### PR DESCRIPTION
Update `AcknowListRowSwiftUIView` to support opening URLs when building for macOS. Fix #114