### PR TITLE
Change acknowledgement access level to open

### DIFF
--- a/Sources/AcknowList/AcknowViewController.swift
+++ b/Sources/AcknowList/AcknowViewController.swift
@@ -32,7 +32,7 @@ open class AcknowViewController: UIViewController {
     open var textView: UITextView?
 
     /// The represented acknowledgement.
-    var acknowledgement: Acknow?
+    open var acknowledgement: Acknow?
 
     /**
      Initializes the `AcknowViewController` instance with an acknowledgement.


### PR DESCRIPTION
**Title**: Make `acknowledgement` Property Accessible for Subclassing

**Problem**:  
The `internal` access level of `AcknowViewController.acknowledgement` blocks subclassing outside the module, causing `'acknowledgement' is inaccessible` errors.

**Solution**:  
- Change `acknowledgement`’s access modifier to `open`.  
- Enable cross-module subclassing and customization.

**Testing**:  
- Created a subclass of `AcknowViewController`.  
- Validated property access and GitHub license fetching.

**Benefits**:  
- ✨ Enables advanced view controller customization.  
- ✅ Aligns with Swift’s access control guidelines.

---

Hi maintainers! 👋  
This fix resolves a common subclassing limitation. Would love your feedback! 🙌  
