### PR TITLE
feat: acknowledgment swiftui element nullable property for settable p…

### DIFF
--- a/Sources/AcknowList/AcknowListSwiftUI.swift
+++ b/Sources/AcknowList/AcknowListSwiftUI.swift
@@ -35,6 +35,9 @@ public struct AcknowListSwiftUIView: View {
 
     /// The represented array of `Acknow`.
     public var acknowledgements: [Acknow] = []
+    
+    /// Page title to be displayed on top of the page.
+    public var pageTitle: String?
 
     /// Header text to be displayed above the list of the acknowledgements.
     public var headerText: String?
@@ -61,8 +64,12 @@ public struct AcknowListSwiftUIView: View {
         footerText = acknowList.footerText
     }
 
-    public init(acknowledgements: [Acknow], headerText: String? = nil, footerText: String? = nil) {
+    public init(acknowledgements: [Acknow],
+                pageTitle: String? = nil,
+                headerText: String? = nil,
+                footerText: String? = nil) {
         self.acknowledgements = acknowledgements
+        self.pageTitle = pageTitle
         self.headerText = headerText
         self.footerText = footerText
     }
@@ -108,7 +115,7 @@ public struct AcknowListSwiftUIView: View {
             }
         }
         .listStyle(GroupedListStyle())
-        .navigationBarTitle(Text(AcknowLocalization.localizedTitle()))
+        .navigationBarTitle(Text(pageTitle ?? AcknowLocalization.localizedTitle()))
 #else
         List {
             Section(header: HeaderFooter(text: headerText), footer: HeaderFooter(text: footerText)) {
@@ -195,6 +202,11 @@ struct AcknowListSwiftUI_Previews: PreviewProvider {
 
         NavigationView {
             AcknowListSwiftUIView(acknowledgements: acks, headerText: "Test Header", footerText: "Test Footer")
+        }
+        .previewDevice(PreviewDevice(rawValue: "iPhone 12"))
+        
+        NavigationView {
+            AcknowListSwiftUIView(acknowledgements: acks, pageTitle: "Test Title")
         }
         .previewDevice(PreviewDevice(rawValue: "iPhone 12"))
 


### PR DESCRIPTION
# Changes in `AcknowListSwiftUIView.swift`

## Summary
This update introduces a new `pageTitle` property to `AcknowListSwiftUIView` and modifies the initializer to accommodate this addition. Additionally, `navigationBarTitle` now uses `pageTitle` when available. Updates have also been made to the preview provider to reflect these changes.

## Changes
### 1. Added a `pageTitle` Property
- Introduced a new optional `pageTitle: String?` property.
- This allows customization of the page title displayed in the navigation bar.

### 2. Modified Initializer
- Updated the initializer to accept `pageTitle` as an additional optional parameter.
- Adjusted assignments accordingly.

### 3. Updated `navigationBarTitle`
- Replaced the static `AcknowLocalization.localizedTitle()` with `pageTitle ?? AcknowLocalization.localizedTitle()`.
- This ensures that `pageTitle` is used if provided.

### 4. Updated Preview Provider
- Added a new preview scenario where `pageTitle` is explicitly set.
- Ensured existing previews remain functional.

## Impact
- Allows greater flexibility in setting custom page titles.
- Maintains backward compatibility by keeping `headerText` and `footerText` unchanged.
- Improves UI customization options for consumers of `AcknowListSwiftUIView`.
- Fixes https://github.com/vtourraine/AcknowList/issues/109