### PR TITLE
Remove explicit GroupedListStyle from AcknowListSwiftUI

### DIFF
--- a/Sources/AcknowList/AcknowListSwiftUI.swift
+++ b/Sources/AcknowList/AcknowListSwiftUI.swift
@@ -98,25 +98,23 @@ public struct AcknowListSwiftUIView: View {
         }
     }
 
+    private var acknowListContent: some View {
+        List {
+            Section(header: HeaderFooter(text: headerText), footer: HeaderFooter(text: footerText)) {
+                ForEach(acknowledgements) { acknowledgement in
+                    AcknowListRowSwiftUIView(acknowledgement: acknowledgement)
+                }
+            }
+        }
+    }
+    
     public var body: some View {
 #if os(iOS) || os(tvOS)
-        List {
-            Section(header: HeaderFooter(text: headerText), footer: HeaderFooter(text: footerText)) {
-                ForEach(acknowledgements) { acknowledgement in
-                    AcknowListRowSwiftUIView(acknowledgement: acknowledgement)
-                }
-            }
-        }
-        .listStyle(GroupedListStyle())
-        .navigationBarTitle(Text(AcknowLocalization.localizedTitle()))
+        acknowListContent
+            .listStyle(GroupedListStyle())
+            .navigationBarTitle(Text(AcknowLocalization.localizedTitle()))
 #else
-        List {
-            Section(header: HeaderFooter(text: headerText), footer: HeaderFooter(text: footerText)) {
-                ForEach(acknowledgements) { acknowledgement in
-                    AcknowListRowSwiftUIView(acknowledgement: acknowledgement)
-                }
-            }
-        }
+        acknowListContent
 #endif
     }
 }
@@ -214,3 +212,4 @@ struct AcknowListSwiftUI_Previews: PreviewProvider {
         .previewDevice(PreviewDevice(rawValue: "Mac"))
     }
 }
+

--- a/Sources/AcknowList/AcknowListSwiftUI.swift
+++ b/Sources/AcknowList/AcknowListSwiftUI.swift
@@ -111,7 +111,6 @@ public struct AcknowListSwiftUIView: View {
     public var body: some View {
 #if os(iOS) || os(tvOS)
         acknowListContent
-            .listStyle(GroupedListStyle())
             .navigationBarTitle(Text(AcknowLocalization.localizedTitle()))
 #else
         acknowListContent

--- a/Sources/AcknowList/AcknowListSwiftUI.swift
+++ b/Sources/AcknowList/AcknowListSwiftUI.swift
@@ -211,4 +211,3 @@ struct AcknowListSwiftUI_Previews: PreviewProvider {
         .previewDevice(PreviewDevice(rawValue: "Mac"))
     }
 }
-


### PR DESCRIPTION
**Summary**
- Removes the explicit .listStyle(GroupedListStyle()) modifier from AcknowListSwiftUIView. This allows the SwiftUI List to use the platform’s default style, providing a more native and adaptive appearance across platforms.
- Removed duplicated code for lists encapsulating the view in a reusable variable over the file.
- Removes the extra blank line at the end of the file, ensuring the file ends with a single newline.

**Motivation**
- Allowing the system’s default list style improves consistency with user preferences and platform conventions.

Testing
- Verified that acknowledgements still appear correctly in the list.
- Confirmed there is no explicit list style set and also that all unit tests pass.

⸻
Main motivation was the styling to be consistent, the duplicity of code for the list is not that important, hopefully you can take the change in consideration for this library, if it doesn't align with what you want I understand, and I'm really grateful for your work in it.