### PR TITLE
Allow initialization and addition of AcknowList 

### DIFF
--- a/Sources/AcknowList/AcknowList.swift
+++ b/Sources/AcknowList/AcknowList.swift
@@ -37,14 +37,20 @@ public struct AcknowList {
      Footer text to be displayed below the list of the acknowledgements.
      */
     public let footerText: String?
+    
+    public init(headerText: String? = nil, acknowledgements: [Acknow], footerText: String? = nil) {
+        self.headerText = headerText
+        self.acknowledgements = acknowledgements
+        self.footerText = footerText
+    }
 }
 
 extension AcknowList {
-    static func +(lhs: AcknowList, rhs: AcknowList) -> AcknowList {
-            return AcknowList(
-                headerText: lhs.headerText ?? rhs.headerText,
-                acknowledgements: lhs.acknowledgements + rhs.acknowledgements,
-                footerText: lhs.footerText ?? rhs.footerText
-            )
-        }
+    public static func +(lhs: AcknowList, rhs: AcknowList) -> AcknowList {
+        return AcknowList(
+            headerText: lhs.headerText ?? rhs.headerText,
+            acknowledgements: lhs.acknowledgements + rhs.acknowledgements,
+            footerText: lhs.footerText ?? rhs.footerText
+        )
+    }
 }


### PR DESCRIPTION
I am using Acknowlist with SwiftUI and generate the list from the package, which works great.

However, I need to add items to the list, that are not in the package (e.g. graphics licenses, etc.). But the defined `+` operator for two `AcknowList` is not public. Initializing of a `AcknowList` is also not possible from outside the package and the properties including the `acknowledgements` on an `AcknowList` are defined with `let` and therefor can not be mutated.

This PR fixes the first two things, so you can do stuff like:

```
let listFromPackage = try! AcknowPackageDecoder().decode(from: packageData)

let customList = AcknowList(headerText: nil, acknowledgements: [
    Acknow(title: "Some Graphics", license: "License of the graphics")
], footerText: nil)

let combinedAcknowList = customList + listFromPackage
```

but not (because the `acknowledgments` property is a `let` instead of a `var`):

```
let url = Bundle.main.url(forResource: "Package", withExtension: "resolved")!
let data = try! Data(contentsOf: url)
var list = try! AcknowPackageDecoder().decode(from: data)
list.acknowledgments.append(Acknow(title: "Some Graphics", license: "License of the graphics"))
```